### PR TITLE
admin edit post

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -167,7 +167,7 @@ response
             "headerImage": "www.headerImage.com/image.jpg",
             "excerpt": "<p>Designing Api Architecture</p>\n",
             "slug": "api-architecture",
-            "author": "BBola Winslow",
+            "author": "Bola Winslow",
             "content": "<h1>Api Architecture content</h1>\n"
         }
     }

--- a/docs/api.md
+++ b/docs/api.md
@@ -91,7 +91,7 @@ mutation {
       headerImage: "www.headerImage.com/image.jpg",
       excerpt: "<p>Designing Api Architecture</p>\n",
       author: "Ben Simmone",
-      content: "<h1>Api Architecture</h1>\n"
+      content: "<h1>Api Architecture content</h1>\n"
       ) {
     id
     title
@@ -114,7 +114,7 @@ response
             "excerpt": "<p>Designing Api Architecture</p>\n",
             "slug": "api-architecture",
             "author": "Ben Simmone",
-            "content": "<h1>Api Architecture</h1>\n"
+            "content": "<h1>Api Architecture content</h1>\n"
         }
     }
 }
@@ -132,6 +132,44 @@ response
 {
     "data": {
         "deletePost": "post with id 5 deleted successfully"
+    }
+}
+```
+
+### Edit a post
+request
+```javascript
+mutation {
+  editPost(
+      id: 2,
+      title: "Api Architecture",
+      headerImage: "www.headerImage.com/image.jpg",
+      excerpt: "<p>Designing Api Architecture</p>\n",
+      author: "Bola Winslow"
+      ) {
+    id
+    title
+    headerImage
+    excerpt
+    slug
+    author
+    content
+  }
+}
+```
+response
+```json
+{
+    "data": {
+        "addPost": {
+            "id": 2,
+            "title": "Api Architecture",
+            "headerImage": "www.headerImage.com/image.jpg",
+            "excerpt": "<p>Designing Api Architecture</p>\n",
+            "slug": "api-architecture",
+            "author": "BBola Winslow",
+            "content": "<h1>Api Architecture content</h1>\n"
+        }
     }
 }
 ```

--- a/src/generated/resolvers.js
+++ b/src/generated/resolvers.js
@@ -92,7 +92,7 @@ const resolvers = {
      * add post
      * @param {object} parent - graphql parent object
      * @param {object} data - graphql input data
-     * destructured { email, password }
+     * destructured { title, headerimage, excerpt, author, content }
      * @param {object} models - database model
      * @returns {object} user - The user object
      */
@@ -126,6 +126,38 @@ const resolvers = {
       if (!admin) errors(req.res, 'Not Authorized', 403);
       await models.Post.destroy({ where: { id } });
       return `post with id ${id} deleted successfully`;
+    },
+    /**
+     * edit a  post
+     * @param {object} parent - graphql parent object
+     * @param {object} data - graphql input data
+     * destructured { title, headerimage, excerpt, author, content }
+     * @param {object} models - database model
+     * @returns {object} user - The user object
+     */
+    editPost: async (parent, {
+      id,
+      title,
+      headerImage,
+      excerpt,
+      author,
+      content
+    }, {req, admin, models }) => {
+      if (!admin) errors(req.res, 'Not Authorized', 403);
+      const slug = title.replace(/ /g, '-').toLowerCase();
+      const updateData = {
+        title,
+        headerImage,
+        excerpt,
+        slug,
+        author,
+        content
+      };
+      const [rowaffected, [entity]] = await models.Post.update(
+        updateData, { returning: true, where: { id } }
+      );
+      if (!rowaffected) errors(req.res, 'post to be edited not found', 404);
+      return entity.dataValues;
     }
   },
 };

--- a/src/generated/resolvers.js
+++ b/src/generated/resolvers.js
@@ -41,16 +41,12 @@ const resolvers = {
         lastName,
         adminKey
       }, { req, models }) => {
-      // check if user with email and password already exists
       let member = await models.Admin.findOne({ where: { username } });
       if (member) errors(req.res, 'username is taken', 400);
       member = await models.Admin.findOne({ where: { email } });
       if (member) errors(req.res, 'Admin with email exists', 409);
-      // check admin key
       if (adminKey !== ADMIN_KEY) throw new Error('Invalid admin key');
-      // hash admin password
       const hashedPassword = await bcrypt.hash(password, 10);
-      // add admin to database
       const { dataValues: admin } = await models.Admin.create({
         firstName,
         lastName,
@@ -58,7 +54,6 @@ const resolvers = {
         email,
         password: hashedPassword
       });
-      // create token for user and add to response
       const token = jwt.sign({
         id: admin.id,
         email: admin.email

--- a/src/generated/typeDefs.js
+++ b/src/generated/typeDefs.js
@@ -29,6 +29,7 @@ const typeDefs = gql`
     signup(username: String!, email: String!, password: String!, firstName: String!, lastName: String!, adminKey: String!): Admin!
     login(email: String!, password: String): Admin!
     addPost(title: String!, headerImage: String!, excerpt: String!, author: String!, content: String!): Post!
+    editPost(id: Int!, title: String, headerImage: String, excerpt: String, author: String, content: String): Post!
     deletePost(id: Int!): String!
   }
 `;

--- a/src/test/app.test.js
+++ b/src/test/app.test.js
@@ -177,6 +177,125 @@ describe('Add Post', () => {
   });
 });
 
+describe('Edit Post', () => {
+  it('should successfuly edit a post', async () => {
+    const response = await chai
+      .request(server)
+      .post('/graphql')
+      .set('Cookie', `token=${token}`)
+      .send({
+        query: `mutation {
+          editPost(
+              id: ${postId}
+              title: "How to be greater",
+              headerImage: "www.headerImage.com/image.jpg",
+              excerpt: "<p>Being great is no easy feat, let me show you how to achievve this</p>\\n",
+              author: "Ben Simmone",
+              content: "<h1>Newsletter Api</h1>\\n<p>This is an architecture of a lightweight newsletter backend server used by the zicli site. This architecture is opensource, so its operation will be independent with admins, newsletter, comments(if neccessary), or likes.\\nThe specifications in this document are subject to change as it is an opensouce project.</p>\\n<h2>Goal</h2>\\n<p>This app aims at creating a simple and dynamic newsletter that can be rivaled with best newsletter apis around the world.</p>\\n<ul>\\n<li>It must be simple</li>\\n<li>It must be dynamic</li>\\n<li>It must be independent</li>\\n<li>It must be abstract.</li>\\n</ul>\\n"
+              ) {
+            id
+            title
+            headerImage
+            excerpt
+            slug
+            author
+            content
+          }
+        }`
+      });
+    expect(response).to.have.status(200);
+    expect(response.body.data).to.be.a('object');
+    expect(response.body.data.editPost.title).to.be.a('string');
+    expect(response.body.data.editPost.content).to.be.a('string');
+  });
+  it('should fail to edit a post if token is absent', async () => {
+    const response = await chai
+      .request(server)
+      .post('/graphql')
+      .send({
+        query: `mutation {
+        editPost(
+            id: ${postId}
+            title: "How to be greater",
+            headerImage: "www.headerImage.com/image.jpg",
+            excerpt: "<p>Being great is no easy feat, let me show you how to achievve this</p>\\n",
+            author: "Ben Simmone",
+            content: "<h1>Newsletter Api</h1>\\n<p>This is an architecture of a lightweight newsletter backend server used by the zicli site. This architecture is opensource, so its operation will be independent with admins, newsletter, comments(if neccessary), or likes.\\nThe specifications in this document are subject to change as it is an opensouce project.</p>\\n<h2>Goal</h2>\\n<p>This app aims at creating a simple and dynamic newsletter that can be rivaled with best newsletter apis around the world.</p>\\n<ul>\\n<li>It must be simple</li>\\n<li>It must be dynamic</li>\\n<li>It must be independent</li>\\n<li>It must be abstract.</li>\\n</ul>\\n"
+            ) {
+          id
+          title
+          headerImage
+          excerpt
+          slug
+          author
+          content
+        }
+      }`
+      });
+    expect(response).to.have.status(403);
+    expect(response.body.errors).to.be.a('array');
+    expect(response.body.errors[0].message).to.be.a('string');
+  });
+  it('should fail to edit a post if post parameters are in wrong format', async () => {
+    const response = await chai
+      .request(server)
+      .post('/graphql')
+      .set('Cookie', `token=${token}`)
+      .send({
+        query: `mutation {
+      editPost(
+          id: yyy
+          title: "How to be greater",
+          headerImage: "www.headerImage.com/image.jpg",
+          excerpt: "<p>Being great is no easy feat, let me show you how to achievve this</p>\\n",
+          author: "Ben Simmone",
+          content: "<h1>Newsletter Api</h1>\\n<p>This is an architecture of a lightweight newsletter backend server used by the zicli site. This architecture is opensource, so its operation will be independent with admins, newsletter, comments(if neccessary), or likes.\\nThe specifications in this document are subject to change as it is an opensouce project.</p>\\n<h2>Goal</h2>\\n<p>This app aims at creating a simple and dynamic newsletter that can be rivaled with best newsletter apis around the world.</p>\\n<ul>\\n<li>It must be simple</li>\\n<li>It must be dynamic</li>\\n<li>It must be independent</li>\\n<li>It must be abstract.</li>\\n</ul>\\n"
+          ) {
+        id
+        title
+        headerImage
+        excerpt
+        slug
+        author
+        content
+      }
+    }`
+      });
+    expect(response).to.have.status(400);
+    expect(response.body.errors).to.be.a('array');
+    expect(response.body.errors[0].message).to.be.a('string');
+  });
+  it('should fail to edit a post if post does not exist', async () => {
+    const response = await chai
+      .request(server)
+      .post('/graphql')
+      .set('Cookie', `token=${token}`)
+      .send({
+        query: `mutation {
+      editPost(
+          id: 100
+          title: "How to be greater",
+          headerImage: "www.headerImage.com/image.jpg",
+          excerpt: "<p>Being great is no easy feat, let me show you how to achievve this</p>\\n",
+          author: "Ben Simmone",
+          content: "<h1>Newsletter Api</h1>\\n<p>This is an architecture of a lightweight newsletter backend server used by the zicli site. This architecture is opensource, so its operation will be independent with admins, newsletter, comments(if neccessary), or likes.\\nThe specifications in this document are subject to change as it is an opensouce project.</p>\\n<h2>Goal</h2>\\n<p>This app aims at creating a simple and dynamic newsletter that can be rivaled with best newsletter apis around the world.</p>\\n<ul>\\n<li>It must be simple</li>\\n<li>It must be dynamic</li>\\n<li>It must be independent</li>\\n<li>It must be abstract.</li>\\n</ul>\\n"
+          ) {
+        id
+        title
+        headerImage
+        excerpt
+        slug
+        author
+        content
+      }
+    }`
+      });
+    expect(response).to.have.status(404);
+    expect(response.body.errors).to.be.a('array');
+    expect(response.body.errors[0].message).to.be.a('string');
+  });
+});
+
 describe('Delete Post', () => {
   it('should fail to delete a post if admin token is absent', async () => {
     const response = await chai


### PR DESCRIPTION
## What it does
This PR allows an admin to edit newsletter posts

## How to test it.
```bash
# clone repo and navigate
git clone https://github.com/zicli/newsletter-api.git && cd newsletter-api

# run tests, but make sure your environmental variables are in order
# see .env.sample
npm run test
```
On Postman graphql query

request
```javascript
mutation {
  editPost(
      id: 2,
      title: "Api Architecture",
      headerImage: "www.headerImage.com/image.jpg",
      excerpt: "<p>Designing Api Architecture</p>\n",
      author: "Bola Winslow"
      ) {
    id
    title
    headerImage
    excerpt
    slug
    author
    content
  }
}
```
response
```json
{
    "data": {
        "addPost": {
            "id": 2,
            "title": "Api Architecture",
            "headerImage": "www.headerImage.com/image.jpg",
            "excerpt": "<p>Designing Api Architecture</p>\n",
            "slug": "api-architecture",
            "author": "Bola Winslow",
            "content": "<h1>Api Architecture content</h1>\n"
        }
    }
}
```
## What's next
- public view all newsletter posts