### PR TITLE
Email enabled for subscribing users

### DIFF
--- a/src/controllers/subscribers.js
+++ b/src/controllers/subscribers.js
@@ -1,7 +1,8 @@
 
-import { Toolbox } from '../utils';
+import { Toolbox, Mailer } from '../utils';
 
 const { errors } = Toolbox;
+const { sendNewSubscriberMessage } = Mailer;
 
 const Subscribers = {
 
@@ -16,11 +17,14 @@ const Subscribers = {
   async addSubscriber(parent, {
     email
   }, { req, models }) {
+    if (!email) return errors(req.res, 'Please Type in an Email', 400);
     const subscriber = await models.Subscriber.findOne({ where: { email } });
     if (subscriber) return errors(req.res, 'Email already exist!', 400);
-    return models.Subscriber.create({
+    const newSubcriber = await models.Subscriber.create({
       email
     });
+    const emailSent = await sendNewSubscriberMessage(email);
+    if (emailSent) return newSubcriber;
   }
 };
 

--- a/src/test/app.test.js
+++ b/src/test/app.test.js
@@ -462,7 +462,7 @@ describe('Add Subscriber Email', () => {
       .send({
         query: `mutation {
           addSubscriber(
-            email: "tozo2345@gmail.com"
+            email: "ozurumbatochukwu@yahoo.com"
           ){
             id
             email

--- a/src/test/app.test.js
+++ b/src/test/app.test.js
@@ -462,7 +462,7 @@ describe('Add Subscriber Email', () => {
       .send({
         query: `mutation {
           addSubscriber(
-            email: "tozo23@gmail.com"
+            email: "tozo2345@gmail.com"
           ){
             id
             email
@@ -482,6 +482,25 @@ describe('Add Subscriber Email', () => {
       .send({
         query: `mutation {
           addSubscriber(
+          ){
+            id
+            email
+            createdAt
+            updatedAt
+          }
+        }`
+      });
+    expect(response.body.errors).to.be.a('array');
+    expect(response.body.errors[0].message).to.be.a('string');
+  });
+  it('should fail to add subscriber if input parameter is missing', async () => {
+    const response = await chai
+      .request(server)
+      .post('/graphql')
+      .send({
+        query: `mutation {
+          addSubscriber(
+            email: ''
           ){
             id
             email

--- a/src/utils/mailer.js
+++ b/src/utils/mailer.js
@@ -10,6 +10,28 @@ sendgrid.setApiKey(SENDGRID_KEY);
 
 const Mailer = {
   /**
+   * send welcome message to subscribers
+   * @param {object} req
+   * @param {Array} emails
+   * @param {URL} newsletterLink
+   * @returns {Promise<boolean>} - Returns true if mail is sent, false if not
+   * @memberof Mailer
+   */
+  async sendNewSubscriberMessage(email) {
+    const mail = {
+      to: email,
+      from: ADMIN_EMAIL,
+      templateId: 'd-8a43cf0796bd4297b917ab6d5951884b',
+    };
+    try {
+      await sendgrid.sendMultiple(mail);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  },
+
+  /**
    * send newsletter to subscribers
    * @param {object} req
    * @param {Array} emails


### PR DESCRIPTION
## What it does
This PR enables Welcome message for subscribing users

## How to test it.
```bash
# clone repo and navigate
git clone https://github.com/zicli/newsletter-api.git && cd newsletter-api

# run tests, but make sure your environmental variables are in order
# see .env.sample
npm run test
```
On Postman graphql query
request
```javascript
mutation {
    addSubscriber(
        email: "ozurumbatochukwu@yahoo.com"
    ) {
        id
        email
        createdAt
        updatedAt
    }
}
```
response
```json
{
    "data": {
        "addSubscriber": {
            "id": 11,
            "email": "ozurumbacdctochukwu@yahoo.com",
            "createdAt": "2020-05-06",
            "updatedAt": "2020-05-06"
        }
    }
}
```